### PR TITLE
Added validation test for mobile number (Page 1)

### DIFF
--- a/cypress/e2e/demoTest/features/testValidation/tests.ts
+++ b/cypress/e2e/demoTest/features/testValidation/tests.ts
@@ -5,10 +5,38 @@ export const validationTests = () => {
   validatePageThree();
 };
 
-//Write your test cases in the following functions
-// Each function should contain test cases for a specific page's validation
 export const validatePageOne = () => {
-  it("should validate structure of page 1", () => {});
+  describe("Page 1 Validation - Mobile Number", () => {
+    // Valid number case
+    it("should accept a valid 10-digit mobile number", () => {
+      const isValid = /^[6-9]\d{9}$/.test("9876543210");
+      expect(isValid).to.eq(true); 
+    });
+
+    // Number shorter than 10 digits
+    it("should reject a number less than 10 digits", () => {
+      const isValid = /^[6-9]\d{9}$/.test("98765");
+      expect(isValid).to.eq(false);
+    });
+
+    // Number longer than 10 digits
+    it("should reject a number with more than 10 digits", () => {
+      const isValid = /^[6-9]\d{9}$/.test("9876543210123");
+      expect(isValid).to.eq(false);
+    });
+
+    // Number not starting with 6–9
+    it("should reject a number starting with digits other than 6-9", () => {
+      const isValid = /^[6-9]\d{9}$/.test("1234567890");
+      expect(isValid).to.eq(false);
+    });
+
+     // Number containing alphabets or non-numeric characters
+    it("should reject non-numeric characters", () => {
+      const isValid = /^[6-9]\d{9}$/.test("98ab56cd10");
+      expect(isValid).to.eq(false);
+    });
+  });
 };
 
 export const validatePageTwo = () => {
@@ -18,3 +46,4 @@ export const validatePageTwo = () => {
 export const validatePageThree = () => {
   it("should validate structure of page 3", () => {});
 };
+

--- a/cypress/e2e/demoTest/features/testValidation/tests.ts
+++ b/cypress/e2e/demoTest/features/testValidation/tests.ts
@@ -33,7 +33,7 @@ export const validatePageOne = () => {
 
      // Number containing alphabets or non-numeric characters
     it("should reject non-numeric characters", () => {
-      const isValid = /^[6-9]\d{9}$/.test("98ab56cd10");
+      const isValid = /^[6-9]\d{9}$/.test("98ab56cd11");
       expect(isValid).to.eq(false);
     });
   });


### PR DESCRIPTION
Description
Added regex-based tests to validate mobile numbers on Page 1, covering valid 10-digit numbers and rejecting invalid inputs (short, long, wrong start, non-numeric).